### PR TITLE
Prepare to version 3 of contract to reorganize admin levels

### DIFF
--- a/src/main/resources/contracts/AccountInitialization.sol
+++ b/src/main/resources/contracts/AccountInitialization.sol
@@ -19,7 +19,7 @@ contract AccountInitialization is ERTTokenV1 {
      * @param _to The address of the account to initialize
      * @param _tokenAmount The amount of tokens to be transfered for account to init
      */
-    function initializeAccount(address _to, uint256 _tokenAmount) public payable onlyAdmin(4) whenNotPaused {
+    function initializeAccount(address _to, uint256 _tokenAmount) public payable onlyAdmin(2) whenNotPaused {
         // Shouldn't initialize a contract address
         require(!super._isContract(_to));
 
@@ -37,7 +37,7 @@ contract AccountInitialization is ERTTokenV1 {
         }
 
         // Approve account to initialize
-        super.approveAccount(_to);
+        super._approveAccount(_to);
 
         // Transfer intial token amount
         if (_tokenAmount > 0) {

--- a/src/main/resources/contracts/AccountRewarding.sol
+++ b/src/main/resources/contracts/AccountRewarding.sol
@@ -19,7 +19,7 @@ contract AccountRewarding is ERTTokenV1 {
      * @param _amount The amount of token to be transferred
      * @param _reward The amount of token to be marked as rewarded
      */
-    function reward(address _to, uint256 _amount, uint256 _reward) public onlyAdmin(2) whenNotPaused whenApproved(_to) {
+    function reward(address _to, uint256 _amount, uint256 _reward) public onlyAdmin(1) whenNotPaused whenApproved(_to) {
         // If no reward, the transfer method should be used instead
         require(_reward > 0);
 

--- a/src/main/resources/contracts/ApprouvableAccount.sol
+++ b/src/main/resources/contracts/ApprouvableAccount.sol
@@ -38,13 +38,7 @@ contract ApprouvableAccount is DataAccess, Admin {
      * @param _target address to approve
      */
     function approveAccount(address _target) public onlyAdmin(4){
-        // Shouldn't approve a contract address
-        require(!_isContract(_target));
-
-        if (!super._isApprovedAccount(_target)) {
-            super._setApprovedAccount(_target, true);
-            emit ApprovedAccount(_target);
-        }
+        _approveAccount(_target);
     }
 
     /**
@@ -76,6 +70,16 @@ contract ApprouvableAccount is DataAccess, Admin {
           size := extcodesize(_addr)
         }
         return (size > 0);
+    }
+
+    function _approveAccount(address _target) internal {
+        // Shouldn't approve a contract address
+        require(!_isContract(_target));
+
+        if (!super._isApprovedAccount(_target)) {
+            super._setApprovedAccount(_target, true);
+            emit ApprovedAccount(_target);
+        }
     }
 
 }

--- a/src/main/resources/test/account-initialization-test.js
+++ b/src/main/resources/test/account-initialization-test.js
@@ -21,13 +21,13 @@ contract('AccountInitialization', function(accounts) {
   });
 
   it('Test initialize account with admin has\'t enough privileges', () => {
-    return tokenInstance.addAdmin(accountsAdmin, 3)
+    return tokenInstance.addAdmin(accountsAdmin, 1)
       .then(() => {
         return tokenInstance.initializeAccount(accountToInitialize, 0, {
           from: accountsAdmin
         });
       }).then(assert.fail).catch((error) => {
-        assert(error.message.indexOf('revert') >= 0, 'Admin level 3 shouldn\'t be able to initialize an account');
+        assert(error.message.indexOf('revert') >= 0, 'Admin level 1 shouldn\'t be able to initialize an account');
       });
   });
 
@@ -49,7 +49,7 @@ contract('AccountInitialization', function(accounts) {
         assert.isAbove(senderEtherBalance, etherToSend, 'Ether to send for account initialization should be less than ether balance of admin account');
 
         // Give admin account enough privileges
-        return tokenInstance.addAdmin(accountsAdmin, 4, {
+        return tokenInstance.addAdmin(accountsAdmin, 2, {
           from : accounts[0]
         });
       }).then(() => {

--- a/src/main/resources/test/account-rewarding-test.js
+++ b/src/main/resources/test/account-rewarding-test.js
@@ -17,8 +17,10 @@ contract('AccountRewarding', function(accounts) {
     tokenInstance = await ERTToken.deployed();
   });
 
-  it("Test reward account with admin not having enough privileges", () => {
-    return tokenInstance.addAdmin(accountsAdmin, 1)
+  it("Test reward account with account not having enough privileges", () => {
+    return tokenInstance.approveAccount(accountToReward, {
+      from : accounts[0]
+    })
       .then(() => {
         // Approve account
         return tokenInstance.approveAccount(accountToReward, {
@@ -34,12 +36,12 @@ contract('AccountRewarding', function(accounts) {
           from: accountsAdmin
         });
       }).then(assert.fail).catch((error) => {
-        assert(error.message.indexOf('revert') >= 0, 'Admin level 1 shouldn\'t be able to reward an account');
+        assert(error.message.indexOf('revert') >= 0, 'Non admin account shouldn\'t be able to reward an account');
       });
   });
 
   it('Test reward account with admin having enough privileges', () => {
-    return tokenInstance.addAdmin(accountsAdmin, 2)
+    return tokenInstance.addAdmin(accountsAdmin, 1)
       .then(() => {
         // Approve account
         return tokenInstance.approveAccount(accountToReward, {


### PR DESCRIPTION
In the ERT Token version 2, the admin levels are defined as follows:
* Level 2: send rewards of wallets
* Level 3: change vesting amount for wallets
* Level 4: approve/disapprove and send initial funds for wallets
* Level 5: set sell price, manage administrators, send funds to Cauri contract, pause/unpause contract and send ether to contract
* Owner: Upgrade contract and transfer ownership

With this PR, the following modification are applied:
* Level 1: send rewards of wallets
* Level 2: initial funds for wallets

This will ensure that 'Admin' wallets of customers doesn't use an admin level to disapprove accounts and to not freely change vesting amounts of users. We will give only required privileges for other 'Admin' accounts other than owner.